### PR TITLE
fix tablet-mode.sh on ubuntu

### DIFF
--- a/tablet/tablet-mode.sh
+++ b/tablet/tablet-mode.sh
@@ -16,4 +16,4 @@ setkeycodes e058 85 # Tablet mode
 setkeycodes e059 89 # Laptop mode
 
 # Start xbindkeys with configuration file
-su $user -c "xbindkeys -f $config"
+su $user -c "xbindkeys -f $config -n"


### PR DESCRIPTION
on Ubuntu xbindkeys doesn't block by default, so the systemd script launces another instance every 5 seconds. This change starts xbindkeys in blocking mode.