### PR TITLE
make mouse toggle work on newer devices

### DIFF
--- a/tablet/mouse-toggle.sh
+++ b/tablet/mouse-toggle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Simple script to toggle on/off the ThinkPad Yoga's Trackpoint and Clickpad
 # and kill/launch. To be binded with switches when switching between tablet/laptop
 # modes.
@@ -10,14 +10,13 @@
 
 case "$1" in
     off)
-	xinput --set-prop "SynPS/2 Synaptics TouchPad" "Device Enabled" 0
-	xinput --set-prop "TPPS/2 IBM TrackPoint" "Device Enabled" 0
+	xinput --set-prop "$(xinput list --name-only | grep -i 'TouchPad')" "Device Enabled" 0
+	xinput --set-prop "$(xinput list --name-only | grep -i 'TrackPoint')" "Device Enabled" 0
 	sudo -b -u \#1000 onboard
 	;;
     on)
-	xinput --set-prop "SynPS/2 Synaptics TouchPad" "Device Enabled" 1
-	xinput --set-prop "TPPS/2 IBM TrackPoint" "Device Enabled" 1
+	xinput --set-prop "$(xinput list --name-only | grep -i 'TouchPad')" "Device Enabled" 1
+	xinput --set-prop "$(xinput list --name-only | grep -i 'TrackPoint')" "Device Enabled" 1
 	killall onboard
 	;;
 esac
-


### PR DESCRIPTION
Implementation of mouse-toggle.sh was changed, so that it works independently of manufacturer name.
Previously this only worked for TouchPads made by Synaptics and TrackPoints made by IBM.
Newer ThinkPad Devices (for example L380) have TouchPads and TrackPoints made by Elan/Elantech.
By using xinput list and grep we can simply use the full device name.