### PR TITLE
Fix rotate for l380 on manjaro

### DIFF
--- a/rotate/thinkpad-rotate.py
+++ b/rotate/thinkpad-rotate.py
@@ -50,7 +50,7 @@ env = environ.copy()
 
 devices = check_output(['xinput', '--list', '--name-only'],env=env).splitlines()
 
-touchscreen_names = ['touchscreen', 'touch digitizer']
+touchscreen_names = ['touchscreen', 'touch digitizer', 'multitouch']
 touchscreens = [i for i in devices if any(j in i.lower() for j in touchscreen_names)]
 
 wacoms = [i for i in devices if any(j in i.lower() for j in ['wacom'])]


### PR DESCRIPTION
Hi,
on manjaro `xinput --list` shows the following 
```
⎡ Virtual core pointer                    	id=2	[master pointer  (3)]
⎜   ↳ Virtual core XTEST pointer              	id=4	[slave  pointer  (2)]
⎜   ↳ Wacom Pen and multitouch sensor Finger  	id=10	[slave  pointer  (2)]
⎜   ↳ Elan Touchpad                           	id=12	[slave  pointer  (2)]
⎜   ↳ Elan TrackPoint                         	id=13	[slave  pointer  (2)]
⎜   ↳ Wacom Pen and multitouch sensor Pen Pen (0x9cd1ae17)	id=16	[slave  pointer  (2)]
⎣ Virtual core keyboard                   	id=3	[master keyboard (2)]
    ↳ Virtual core XTEST keyboard             	id=5	[slave  keyboard (3)]
    ↳ Power Button                            	id=6	[slave  keyboard (3)]
    ↳ Video Bus                               	id=7	[slave  keyboard (3)]
    ↳ Sleep Button                            	id=8	[slave  keyboard (3)]
    ↳ Integrated Camera: Integrated C         	id=9	[slave  keyboard (3)]
    ↳ Wacom Pen and multitouch sensor Pen     	id=11	[slave  keyboard (3)]
    ↳ AT Translated Set 2 keyboard            	id=14	[slave  keyboard (3)]
    ↳ ThinkPad Extra Buttons                  	id=15	[slave  keyboard (3)]

``` 

That is, the rotate script currently doesn't adjust the inputs from the touch-screen. This PR fixed this for me...